### PR TITLE
[rust] use mutable reference to entries before sort

### DIFF
--- a/rust/json-canon/src/object.rs
+++ b/rust/json-canon/src/object.rs
@@ -148,7 +148,7 @@ impl Object {
     {
         CompactFormatter.begin_object(writer)?;
 
-        let mut entries = self.entries.clone();
+        let entries = &mut self.entries;
 
         entries.sort_by(|a, b| a.cmpable().cmp(b.cmpable()));
 


### PR DESCRIPTION
bench:

```
                        time:   [22.139 µs 22.176 µs 22.217 µs]
                        thrpt:  [45.010 Kelem/s 45.093 Kelem/s 45.170 Kelem/s]
                 change:
                        time:   [-23.567% -23.340% -23.129%] (p = 0.00 < 0.05)
                        thrpt:  [+30.087% +30.447% +30.833%
```