### PR TITLE
[rust] object pooling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,20 +91,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2801af0d36612ae591caa9568261fddce32ce6e08a7275ea334a06a4ad021a2c"
-dependencies = [
- "cfg-if",
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-epoch",
- "crossbeam-queue",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-channel"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -179,29 +165,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "easy-pool"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7e5ff17f98f39dbe4214cdf737ba15729852ccc7c701462adbe406af91d6a51"
-dependencies = [
- "crossbeam",
- "easy_pool_proc_macro",
- "once_cell",
- "parking_lot",
-]
-
-[[package]]
-name = "easy_pool_proc_macro"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4e720f99fb79c02058af2ee61f5072fbc30d53fcd59d2ae0e57a0827b1fafd"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "either"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -260,7 +223,8 @@ name = "json-canon"
 version = "0.1.3"
 dependencies = [
  "criterion",
- "easy-pool",
+ "crossbeam-queue",
+ "lazy_static",
  "ryu-js",
  "serde",
  "serde_derive",
@@ -278,16 +242,6 @@ name = "libc"
 version = "0.2.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
-
-[[package]]
-name = "lock_api"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
-dependencies = [
- "autocfg",
- "scopeguard",
-]
 
 [[package]]
 name = "log"
@@ -343,29 +297,6 @@ name = "oorandom"
 version = "11.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
-
-[[package]]
-name = "parking_lot"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-sys",
-]
 
 [[package]]
 name = "plotters"
@@ -436,15 +367,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
 name = "regex"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -510,7 +432,7 @@ checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn",
 ]
 
 [[package]]
@@ -522,23 +444,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "smallvec"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
 ]
 
 [[package]]
@@ -614,7 +519,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -636,7 +541,7 @@ checksum = "4783ce29f09b9d93134d41297aded3a712b7b979e9c6f28c32cb88c973a94869"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -687,69 +592,3 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,6 +91,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2801af0d36612ae591caa9568261fddce32ce6e08a7275ea334a06a4ad021a2c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -125,6 +139,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-queue"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1cfb3ea8a53f37c40dea2c7bedcbd88bdfae54f5e2175d6ecaff1c988353add"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -152,6 +176,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "easy-pool"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7e5ff17f98f39dbe4214cdf737ba15729852ccc7c701462adbe406af91d6a51"
+dependencies = [
+ "crossbeam",
+ "easy_pool_proc_macro",
+ "once_cell",
+ "parking_lot",
+]
+
+[[package]]
+name = "easy_pool_proc_macro"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf4e720f99fb79c02058af2ee61f5072fbc30d53fcd59d2ae0e57a0827b1fafd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -213,6 +260,7 @@ name = "json-canon"
 version = "0.1.3"
 dependencies = [
  "criterion",
+ "easy-pool",
  "ryu-js",
  "serde",
  "serde_derive",
@@ -230,6 +278,16 @@ name = "libc"
 version = "0.2.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
+
+[[package]]
+name = "lock_api"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -285,6 +343,29 @@ name = "oorandom"
 version = "11.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-sys",
+]
 
 [[package]]
 name = "plotters"
@@ -355,6 +436,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regex"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -420,7 +510,7 @@ checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -432,6 +522,23 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -507,7 +614,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.15",
  "wasm-bindgen-shared",
 ]
 
@@ -529,7 +636,7 @@ checksum = "4783ce29f09b9d93134d41297aded3a712b7b979e9c6f28c32cb88c973a94869"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.15",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -580,3 +687,69 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"

--- a/rust/json-canon/Cargo.toml
+++ b/rust/json-canon/Cargo.toml
@@ -14,6 +14,7 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+easy-pool = "0.2.7"
 ryu-js = { version = "0.2.2", default-features = false }
 serde = { version = "1.0.162", default-features = false }
 serde_json = { version = "1.0.96", default-features = false, features = ["std", "float_roundtrip"] }

--- a/rust/json-canon/Cargo.toml
+++ b/rust/json-canon/Cargo.toml
@@ -14,7 +14,8 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-easy-pool = "0.2.7"
+crossbeam-queue = "0.3.8"
+lazy_static = "1.4.0"
 ryu-js = { version = "0.2.2", default-features = false }
 serde = { version = "1.0.162", default-features = false }
 serde_json = { version = "1.0.96", default-features = false, features = ["std", "float_roundtrip"] }

--- a/rust/json-canon/src/lib.rs
+++ b/rust/json-canon/src/lib.rs
@@ -35,6 +35,7 @@
 //!
 
 mod object;
+mod pool;
 mod ser;
 
 pub use self::ser::{to_string, to_vec, to_writer};

--- a/rust/json-canon/src/object.rs
+++ b/rust/json-canon/src/object.rs
@@ -10,7 +10,7 @@ use serde_json::ser::{CompactFormatter, Formatter};
 use crate::pool::{Clear, Pool, PoolObjectContainer};
 
 lazy_static! {
-    static ref POOL: Arc<Pool<ObjectEntry>> = Arc::new(Pool::default());
+    static ref POOL: Arc<Pool<ObjectEntry>> = Arc::new(Pool::with_capacity(256));
 }
 
 #[derive(Clone, Debug)]
@@ -33,9 +33,9 @@ impl Clear for ObjectEntry {
 impl Default for ObjectEntry {
     fn default() -> Self {
         Self {
-            key: Vec::with_capacity(16),
-            key_bytes: Vec::with_capacity(16),
-            value: Vec::with_capacity(64),
+            key: Vec::with_capacity(8),
+            key_bytes: Vec::with_capacity(8),
+            value: Vec::with_capacity(16),
             is_key_done: false,
         }
     }

--- a/rust/json-canon/src/pool.rs
+++ b/rust/json-canon/src/pool.rs
@@ -1,0 +1,110 @@
+use std::{
+    fmt::Debug,
+    mem::ManuallyDrop,
+    ops::{Deref, DerefMut},
+    ptr,
+    sync::Arc,
+};
+
+use crossbeam_queue::ArrayQueue;
+
+pub trait Clear {
+    fn clear(&mut self);
+}
+
+#[derive(Debug)]
+pub struct Pool<T> {
+    pub(crate) values: ArrayQueue<T>,
+    pub(crate) max_size: usize,
+}
+
+impl<T> Pool<T>
+where
+    T: Clear,
+{
+    #[inline]
+    pub fn new(capacity: usize) -> Self {
+        Self {
+            values: ArrayQueue::new(capacity),
+            max_size: capacity,
+        }
+    }
+
+    #[inline]
+    pub fn create(self: Arc<Self>) -> PoolObjectContainer<T>
+    where
+        T: Clear + Default,
+    {
+        let val = self.values.pop().unwrap_or_else(|| Default::default());
+        PoolObjectContainer::new(val, self)
+    }
+
+    #[inline]
+    pub fn max_size(&self) -> usize {
+        self.max_size
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.values.len()
+    }
+
+    #[inline]
+    pub fn push(&self, value: T) -> Result<(), T> {
+        self.values.push(value)
+    }
+}
+
+impl<T: Clear> Default for Pool<T> {
+    #[inline]
+    fn default() -> Self {
+        Self::new(1024)
+    }
+}
+
+#[derive(Debug)]
+pub struct PoolObjectContainer<T: Clear> {
+    pool: Arc<Pool<T>>,
+    inner: ManuallyDrop<T>,
+}
+
+impl<T: Clear> PoolObjectContainer<T> {
+    #[inline]
+    fn new(val: T, pool: Arc<Pool<T>>) -> Self {
+        Self {
+            pool,
+            inner: ManuallyDrop::new(val),
+        }
+    }
+}
+
+impl<T: Clear> Deref for PoolObjectContainer<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl<T: Clear> DerefMut for PoolObjectContainer<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+
+impl<T: Clear> Drop for PoolObjectContainer<T> {
+    fn drop(&mut self) {
+        let val = unsafe { ptr::read(&self.inner) };
+        let mut val = ManuallyDrop::into_inner(val);
+
+        let pool = &self.pool;
+        if pool.len() >= pool.max_size() {
+            drop(val);
+        } else {
+            val.clear();
+            if let Err(val) = pool.push(val) {
+                drop(val);
+            }
+        }
+    }
+}

--- a/rust/json-canon/src/pool.rs
+++ b/rust/json-canon/src/pool.rs
@@ -23,7 +23,7 @@ where
     T: Clear,
 {
     #[inline]
-    pub fn new(capacity: usize) -> Self {
+    pub fn with_capacity(capacity: usize) -> Self {
         Self {
             values: ArrayQueue::new(capacity),
             max_size: capacity,
@@ -55,13 +55,6 @@ where
     }
 }
 
-impl<T: Clear> Default for Pool<T> {
-    #[inline]
-    fn default() -> Self {
-        Self::new(1024)
-    }
-}
-
 #[derive(Debug)]
 pub struct PoolObjectContainer<T: Clear> {
     pool: Arc<Pool<T>>,
@@ -81,12 +74,14 @@ impl<T: Clear> PoolObjectContainer<T> {
 impl<T: Clear> Deref for PoolObjectContainer<T> {
     type Target = T;
 
+    #[inline]
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
 
 impl<T: Clear> DerefMut for PoolObjectContainer<T> {
+    #[inline]
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }

--- a/rust/json-canon/src/ser.rs
+++ b/rust/json-canon/src/ser.rs
@@ -71,7 +71,7 @@ static MAX_SAFE_INTEGER_I64: i64 = 9_007_199_254_740_991;
 static MAX_SAFE_INTEGER_U128: u128 = 9_007_199_254_740_991;
 static MAX_SAFE_INTEGER_I128: i128 = 9_007_199_254_740_991;
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 #[repr(transparent)]
 pub struct CanonicalFormatter {
     stack: ObjectStack,


### PR DESCRIPTION
inspired by https://www.reddit.com/r/rust/comments/ozpspr/improved_my_base64_encoders_performance_3x_by/,

i tried to re-use the many `ObjectEntry` objects that get created (and their byte `Vec<u8>`'s) using a pool.

benchmarks look very promising!

```
                        time:   [13.003 µs 13.027 µs 13.061 µs]
                        thrpt:  [76.564 Kelem/s 76.761 Kelem/s 76.904 Kelem/s]
                 change:
                        time:   [-39.290% -39.190% -39.087%] (p = 0.00 < 0.05)
                        thrpt:  [+64.169% +64.447% +64.716%]
```